### PR TITLE
Reverse proxy setup additions

### DIFF
--- a/configuration.md
+++ b/configuration.md
@@ -155,8 +155,8 @@ Make sure that the configured `uid:gid` has read- and write permissions to volum
 
 ### Reverse Proxy and IPs
 
-Running the docker container behind a reverse proxy will show only the IP of the reverse proxy in the log files. With setting `REAL_IP_FROM` to the ip address of the reverse proxy, the IPs of the connection clients will be logged.
+Running the docker container behind a reverse proxy will show only the IP of the reverse proxy in the log files. With setting `REAL_IP_FROM` to the ip address or network of the reverse proxy, the IPs of the connection clients will be logged.
 
-| Variable         |  Example         | Description                                  |
-|------------------|------------------|----------------------------------------------|
-| `REAL_IP_FROM`   | `'10.0.0.0/8'`   | Configure nginx to respect `real_ip_header`, see <http://nginx.org/en/docs/http/ngx_http_realip_module.html> |
+| Variable         |  Example          | Description                                  |
+|------------------|-------------------|----------------------------------------------|
+| `REAL_IP_FROM`   | `'172.20.0.0/24'` | Configure wiki to respect `X-Real-IP` header in the requests coming from this IP or network. |


### PR DESCRIPTION
1. Added correct headers to all reverse proxy config examples. Specifically the `X-Forwarded-Proto` is important so Flask is able to generate correct URLs.
2. Removed the mention of `ngx_http_realip_module` from Configuration, not sure why it was used there, it's not needed for Flask to respect real IPs and nginx does not require any additional modules to add the required header. Please tell me if I misunderstood the reasoning here. Also changed the example network to the one that is typically used in Docker.